### PR TITLE
feat(market-data): add get_24h_volumes(connector_name)

### DIFF
--- a/hummingbot_api_client/__init__.py
+++ b/hummingbot_api_client/__init__.py
@@ -2,5 +2,5 @@ from .client import HummingbotAPIClient
 from .sync_client import SyncHummingbotAPIClient
 from .ws import MarketDataWebSocket, ExecutorsWebSocket, WebSocketRouter
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 __all__ = ["HummingbotAPIClient", "SyncHummingbotAPIClient", "MarketDataWebSocket", "ExecutorsWebSocket", "WebSocketRouter"]

--- a/hummingbot_api_client/routers/market_data.py
+++ b/hummingbot_api_client/routers/market_data.py
@@ -121,7 +121,27 @@ class MarketDataRouter(BaseRouter):
             List of connector names that can be used for fetching candle data
         """
         return await self._get("/market-data/available-candle-connectors")
-    
+
+    async def get_24h_volumes(self, connector_name: str) -> Dict[str, Any]:
+        """
+        Get 24h quote-denominated volume per trading pair for a connector, keyed by
+        Hummingbot trading pair (BASE-QUOTE) so it joins with trading rules.
+
+        A value of 0.0 marks a listed-but-untraded market (e.g. Hyperliquid's
+        permissionless tokenized-equity spot pairs like AAPL-USDC), so clients can
+        rank pairs by volume and hide untraded ones.
+
+        Supported connectors: hyperliquid, hyperliquid_perpetual, binance,
+        binance_perpetual, okx, okx_perpetual.
+
+        Args:
+            connector_name: Exchange connector name
+
+        Returns:
+            {"connector": str, "volumes": {trading_pair: quote_volume_24h}}
+        """
+        return await self._get(f"/market-data/volumes/{connector_name}")
+
     async def get_active_feeds(self) -> Dict[str, Any]:
         """Get information about currently active market data feeds."""
         return await self._get("/market-data/active-feeds")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hummingbot-api-client"
-version = "1.5.3"
+version = "1.5.4"
 description = "An async Python client for Hummingbot API"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

Adds `MarketDataRouter.get_24h_volumes(connector_name)` wrapping the new hummingbot-api endpoint `GET /market-data/volumes/{connector}`.

Returns 24h **quote-denominated** volume per trading pair, keyed by Hummingbot trading pair (`BASE-QUOTE`) so it joins directly with `get_trading_rules`. A value of `0.0` marks a listed-but-untraded market (e.g. Hyperliquid's permissionless tokenized-equity spot pairs like `AAPL-USDC`), letting a client rank a pair selector by volume and hide the zombies.

```python
r = await client.market_data.get_24h_volumes("hyperliquid")
# {"connector": "hyperliquid", "volumes": {"WOW-USDC": 409617350.0, "AAPL-USDC": 0.0, ...}}
```

Supported connectors: `hyperliquid`, `hyperliquid_perpetual`, `binance`, `binance_perpetual`, `okx`, `okx_perpetual`.

- Bumps version `1.5.3 → 1.5.4`.
- The async sync-wrapper exposes it automatically (no per-method change needed).

## Depends on

hummingbot-api endpoint `GET /market-data/volumes/{connector}` (hummingbot/hummingbot-api PR #171).

## Test

Verified live against a running hummingbot-api: `get_24h_volumes("hyperliquid")` → 301 pairs, `AAPL-USDC = 0.0`, top pairs ranked by volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)