### PR TITLE
fix(gateway): add CLMM add/remove liquidity methods, send explicit slippage_pct=0

### DIFF
--- a/hummingbot_api_client/routers/gateway_clmm.py
+++ b/hummingbot_api_client/routers/gateway_clmm.py
@@ -152,7 +152,7 @@ class GatewayCLMMRouter(BaseRouter):
             "pool_address": pool_address,
             "lower_price": str(lower_price),
             "upper_price": str(upper_price),
-            "slippage_pct": str(slippage_pct) if slippage_pct else "1.0"
+            "slippage_pct": str(slippage_pct) if slippage_pct is not None else "1.0"
         }
         if base_token_amount is not None:
             request_data["base_token_amount"] = str(base_token_amount)
@@ -164,6 +164,95 @@ class GatewayCLMMRouter(BaseRouter):
             request_data["extra_params"] = extra_params
 
         return await self._post("/gateway/clmm/open", json=request_data)
+
+    async def add_liquidity(
+        self,
+        connector: str,
+        network: str,
+        position_address: str,
+        base_token_amount: Optional[Decimal] = None,
+        quote_token_amount: Optional[Decimal] = None,
+        slippage_pct: Optional[Decimal] = None,
+        wallet_address: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Add MORE liquidity to an EXISTING CLMM position.
+
+        Args:
+            connector: CLMM connector (e.g., 'meteora')
+            network: Network ID in format 'chain-network' (e.g., 'solana-mainnet-beta')
+            position_address: Existing position address to add liquidity to
+            base_token_amount: Amount of base token to add (optional)
+            quote_token_amount: Amount of quote token to add (optional)
+            slippage_pct: Slippage percentage tolerance (default: 1.0)
+            wallet_address: Wallet address (uses default if not provided)
+
+        Returns:
+            Dict containing transaction_hash, position_address, and status
+
+        Example:
+            result = await client.gateway_clmm.add_liquidity(
+                connector='meteora',
+                network='solana-mainnet-beta',
+                position_address='...',
+                base_token_amount=Decimal('0.5'),
+                quote_token_amount=Decimal('50')
+            )
+        """
+        request_data = {
+            "connector": connector,
+            "network": network,
+            "position_address": position_address,
+            "slippage_pct": str(slippage_pct) if slippage_pct is not None else "1.0"
+        }
+        if base_token_amount is not None:
+            request_data["base_token_amount"] = str(base_token_amount)
+        if quote_token_amount is not None:
+            request_data["quote_token_amount"] = str(quote_token_amount)
+        if wallet_address:
+            request_data["wallet_address"] = wallet_address
+
+        return await self._post("/gateway/clmm/add", json=request_data)
+
+    async def remove_liquidity(
+        self,
+        connector: str,
+        network: str,
+        position_address: str,
+        percentage: Decimal,
+        wallet_address: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Remove SOME liquidity from a CLMM position (partial removal).
+
+        Args:
+            connector: CLMM connector (e.g., 'meteora')
+            network: Network ID in format 'chain-network' (e.g., 'solana-mainnet-beta')
+            position_address: Position address to remove liquidity from
+            percentage: Percentage of liquidity to remove (0-100)
+            wallet_address: Wallet address (uses default if not provided)
+
+        Returns:
+            Dict containing transaction_hash, position_address, percentage, and status
+
+        Example:
+            result = await client.gateway_clmm.remove_liquidity(
+                connector='meteora',
+                network='solana-mainnet-beta',
+                position_address='...',
+                percentage=Decimal('50')
+            )
+        """
+        request_data = {
+            "connector": connector,
+            "network": network,
+            "position_address": position_address,
+            "percentage": str(percentage)
+        }
+        if wallet_address:
+            request_data["wallet_address"] = wallet_address
+
+        return await self._post("/gateway/clmm/remove", json=request_data)
 
     async def close_position(
         self,

--- a/hummingbot_api_client/routers/gateway_swap.py
+++ b/hummingbot_api_client/routers/gateway_swap.py
@@ -47,7 +47,7 @@ class GatewaySwapRouter(BaseRouter):
             "trading_pair": trading_pair,
             "side": side,
             "amount": str(amount),
-            "slippage_pct": str(slippage_pct) if slippage_pct else "1.0"
+            "slippage_pct": str(slippage_pct) if slippage_pct is not None else "1.0"
         }
         return await self._post("/gateway/swap/quote", json=request_data)
 
@@ -93,7 +93,7 @@ class GatewaySwapRouter(BaseRouter):
             "trading_pair": trading_pair,
             "side": side,
             "amount": str(amount),
-            "slippage_pct": str(slippage_pct) if slippage_pct else "1.0"
+            "slippage_pct": str(slippage_pct) if slippage_pct is not None else "1.0"
         }
         if wallet_address:
             request_data["wallet_address"] = wallet_address

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hummingbot-api-client"
-version = "1.5.3"
+version = "1.5.4"
 description = "An async Python client for Hummingbot API"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

- **`gateway_clmm`: add `add_liquidity()` and `remove_liquidity()`** — the client had no methods for `POST /gateway/clmm/add` and `POST /gateway/clmm/remove` at all.
- **Zero-slippage fix**: `slippage_pct=0` was dropped as falsy (`if slippage_pct` / `or "1.0"`) and silently replaced with the 1.0 default in `gateway_swap.quote_swap`, `gateway_swap.execute_swap`, and `gateway_clmm.open_position`; now uses `is not None`.
- Bump version to **1.5.4**.

Note: `feat/market-data-24h-volumes` (#pending) also bumps to 1.5.4 — whichever merges second should re-bump to 1.5.5 before publishing.

## Test plan

Verified live against hummingbot-api + Gateway on 15888: `remove_liquidity()` on a bogus position address reaches `/gateway/clmm/remove` and returns Gateway's real "Position not found" 404; swap quotes with `slippage_pct=0` round-trip as `"0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ko4KsGwUaHjqiRTYon31Li